### PR TITLE
fix: correct test imports for CI compatibility

### DIFF
--- a/App/TEST/test_db_full_pytest.py
+++ b/App/TEST/test_db_full_pytest.py
@@ -6,7 +6,7 @@ import pytest
 # Ensure the App directory is on sys.path so imports work during pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dblite import Database, DBActions
+from database.dblite import Database, DBActions
 
 
 def setup_db(tmp_path, monkeypatch):

--- a/App/TEST/test_sqlite_pytest.py
+++ b/App/TEST/test_sqlite_pytest.py
@@ -6,7 +6,7 @@ import pytest
 # Ensure the App directory is on sys.path so imports work during pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from sqlite_db import SQLiteDB
+from database.sqlite_db import SQLiteDB
 
 
 def test_initialize_db_creates_file_and_members_table(tmp_path, monkeypatch):

--- a/App/TEST/test_table_manager_pytest.py
+++ b/App/TEST/test_table_manager_pytest.py
@@ -7,7 +7,7 @@ import pytest
 # Ensure App directory is importable
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from dblite import Database, DBActions
+from database.dblite import Database, DBActions
 import table_manager
 from table_manager import TableManager
 


### PR DESCRIPTION
The initial CI merge had test import errors: tests imported \dblite\ and \sqlite_db\ as top-level modules, but they're inside the \database/\ package. This fixes the imports so tests can be discovered and run by pytest.