### PR TITLE
fix: correct test imports and YAML syntax for CI pipeline

### DIFF
--- a/App/TEST/test_db_full_pytest.py
+++ b/App/TEST/test_db_full_pytest.py
@@ -6,7 +6,7 @@ import pytest
 # Ensure the App directory is on sys.path so imports work during pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from dblite import Database, DBActions
+from database.dblite import Database, DBActions
 
 
 def setup_db(tmp_path, monkeypatch):

--- a/App/TEST/test_sqlite_pytest.py
+++ b/App/TEST/test_sqlite_pytest.py
@@ -6,7 +6,7 @@ import pytest
 # Ensure the App directory is on sys.path so imports work during pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from sqlite_db import SQLiteDB
+from database.sqlite_db import SQLiteDB
 
 
 def test_initialize_db_creates_file_and_members_table(tmp_path, monkeypatch):

--- a/App/TEST/test_table_manager_pytest.py
+++ b/App/TEST/test_table_manager_pytest.py
@@ -7,7 +7,7 @@ import pytest
 # Ensure App directory is importable
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from dblite import Database, DBActions
+from database.dblite import Database, DBActions
 import table_manager
 from table_manager import TableManager
 


### PR DESCRIPTION
Fixes two issues discovered after the initial CI merge:\n\n1. **Test imports** — tests imported \dblite\ and \sqlite_db\ as top-level modules, but they're inside the \database/\ package. Changed to \rom database.dblite import ...\ and \rom database.sqlite_db import ...\.\n\n2. **YAML syntax** — inline PowerShell here-string in the workflow file broke the YAML block scalar due to indentation mismatch. Moved spec generation to \scripts/ci_build.py --generate-spec\.\n\n**Known remaining issue:** \	est_db_full_pytest.py\ and \	est_table_manager_pytest.py\ will still fail because the points methods (\dd_points\, \get_member_points\, \edeem_points\) are commented out in the codebase.