### PR TITLE
fix: unique CI issue titles and table_manager import

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,8 +42,8 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Build aborted — tests failed on main`,
-              body: `## Test Failure Report\n\nTests failed after merge to \`main\`.\n\n<details><summary>JUnit output</summary>\n\n\`\`\`\n${results}\n\`\`\`\n\n</details>\n\n_Triggered by commit ${context.sha}_`
+              title: `Build aborted — tests failed on main (${context.sha.substring(0,7)})`,
+              body: `## Test Failure Report\n\nTests failed after merge to \`main\`.\n\n**Commit:** \`${context.sha}\`\n**Date:** ${new Date().toISOString()}\n\n<details><summary>JUnit output</summary>\n\n\`\`\`\n${results}\n\`\`\`\n\n</details>\n\n_Triggered by commit ${context.sha}_`
             });
 
       - name: Fail if tests failed

--- a/App/TEST/test_table_manager_pytest.py
+++ b/App/TEST/test_table_manager_pytest.py
@@ -8,8 +8,7 @@ import pytest
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from database.dblite import Database, DBActions
-import table_manager
-from table_manager import TableManager
+from managers.table_manager import TableManager
 
 
 class DummyEntry:


### PR DESCRIPTION
Two fixes:\n\n1. **Unique issue titles** — when tests fail, the created issue now includes the commit SHA in the title to avoid duplicate name conflicts.\n2. **table_manager import** — import table_manager changed to rom managers.table_manager import TableManager so CI can find the module.