### PR TITLE
fix: PyInstaller DLL error — install VC++ redist and update action versions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create issue on test failure
         if: steps.tests.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -100,7 +100,7 @@ jobs:
           git push origin "${{ steps.version.outputs.version }}"
 
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.21.0
         with:
           tag: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,13 +13,18 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Install VC++ redistributable
+        run: |
+          curl.exe -sL -o vc_redist.x64.exe "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+          .\vc_redist.x64.exe /quiet /norestart
 
       - name: Install dependencies
         run: |

--- a/scripts/ci_build.py
+++ b/scripts/ci_build.py
@@ -58,8 +58,8 @@ def generate_spec(version: str, output_dir: str = "App/build") -> str:
     content = f"""# -*- mode: python ; coding: utf-8 -*-
 
 a = Analysis(
-    ['main.py'],
-    pathex=[],
+    ['../main.py'],
+    pathex=['..'],
     binaries=[],
     datas=[],
     hiddenimports=[],


### PR DESCRIPTION
Three fixes:\n\n1. **VC++ Redistributable** — installs the VC++ runtime before building so the .exe doesn't fail with 'Failed to load Python DLL' on Windows Server 2025.\n2. **Action versions** — updated to Node 24-compatible versions: \ctions/checkout@v7\, \ctions/setup-python@v6\, \ctions/github-script@v9\.\n3. **Spec path** — changed \['main.py']\ to \['../main.py']\ with \pathex=['..']\ so PyInstaller resolves the script relative to the \App/build/\ spec location.